### PR TITLE
use alpine linux to reduce image footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ubuntu
+FROM alpine:edge
+
 MAINTAINER Christian Lück <christian@lueck.tv>
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
-	httpie
+RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    apk add --no-cache httpie@testing ca-certificates
 
 ENTRYPOINT ["http"]


### PR DESCRIPTION
httpie is only availlable on alpine testing yet, so we need to use alpine:edge for now

> $ docker images | grep http
> httpiealpine                                  latest              928c14ebc275        About a minute ago   52.89 MB
> clue/httpie                                   latest              9803e0722846        5 days ago           244.2 MB

closes #3 
